### PR TITLE
[FEAT-3] Data Caching

### DIFF
--- a/News.iml
+++ b/News.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
@@ -7,9 +7,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/build/classes/main" />
-    <output-test url="file://$MODULE_DIR$/build/classes/test" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ This is a high-level design diagram of the application:
 
 ![Architectural Overview](/docs/architecture.png)
 
-# Branches
-
-The following is a list of all of the features we'll to introduce in the app.
+# Branch Roadmap
 
 ### Feature #1: Timeline and Details Views
 
@@ -39,6 +37,15 @@ This branch introduces networking capabilities using **Retrofit**, allowing the 
 - [x] Model classes definition (`Post.java` and `Media.java`)
 - [x] Display dates in a human-friendly format
 
+### Feature #3: Data Caching
+
+> Branch Codename: `FEAT-3`<br />
+> Link to Pull Request: https://github.com/fknussel/News/pull/3
+
+So far, whenever we want to display a particular post or list the latest articles, we needed to query the API. This is not cool whatsoever, unnecessary network calls should be avoided whenever possible. Instead we should cache the data into our local database immediately after we query the web service for the first time. This is what this branch focuses on, making the app more efficient in terms of network calls.
+
+We also went ahead and made some UI tweaks to `DetailActivity`: the action bar is now transparent, the pictures kinda overlay the action bar but are still fully visible since it's transparent now, also posts' titles get displayed on top of a black-to-transparent gradient applied to the image (we are no longer using the semi-opaque black box underneath the title).
+
 # Dependencies
 
 This application uses the following libraries:
@@ -51,3 +58,12 @@ This application uses the following libraries:
 ### Talking to the Backend
 
 This app is tightly-knit to the RESTful API it gets its data from. The model classes (`Post.java`, `Media.java` and so on) were built upon the API's interfaces. Go check the [web service source code](https://github.com/fknussel/news-backend) to get an insight of how this all works together.
+
+The location of the RESTful API is hardcoded in this class:
+
+```
+public class ApiClient {
+    private static final String API_URL = "http://api.fknussel.com";
+```
+
+**Heads up!** :hand: DO NOT include a trailing slash here.

--- a/app/app.iml
+++ b/app/app.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="News" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -9,6 +9,7 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
+        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugTest" />
@@ -24,6 +25,7 @@
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".MainActivity"
+            android:launchMode="singleTop"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <activity
             android:name=".DetailActivity"
             android:label=""
+            android:theme="@style/CustomActionBarTheme"
             android:parentActivityName=".MainActivity" >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/fknussel/news/DateHelper.java
+++ b/app/src/main/java/com/fknussel/news/DateHelper.java
@@ -1,0 +1,44 @@
+package com.fknussel.news;
+
+import java.util.ArrayList;
+
+import hirondelle.date4j.DateTime;
+
+public class DateHelper {
+    
+    public static String getHumanFriendlyDate(String input) {
+        
+        // months
+        ArrayList<String> months = new ArrayList<>();
+        months.add("Enero");
+        months.add("Febrero");
+        months.add("Marzo");
+        months.add("Abril");
+        months.add("Mayo");
+        months.add("Junio");
+        months.add("Julio");
+        months.add("Agosto");
+        months.add("Septiembre");
+        months.add("Octubre");
+        months.add("Noviembre");
+        months.add("Diciembre");
+
+        // weekdays
+        ArrayList<String> days = new ArrayList<>();
+        days.add("Domingo");
+        days.add("Lunes");
+        days.add("Martes");
+        days.add("Miercoles");
+        days.add("Jueves");
+        days.add("Viernes");
+        days.add("Sábado");
+
+        DateTime dt = new DateTime(input);
+
+        String weekDay = days.get(dt.getWeekDay() - 1);
+        String day = dt.getDay().toString();
+        String month = months.get(dt.getMonth() - 1);
+
+        return weekDay + " " + day + " de " + month;
+    }
+}

--- a/app/src/main/java/com/fknussel/news/DbContract.java
+++ b/app/src/main/java/com/fknussel/news/DbContract.java
@@ -1,0 +1,12 @@
+package com.fknussel.news;
+
+public class DbContract {
+
+    // DB specific constants
+    // ---------------------------
+    // This is the actual SQLite file that will contain the database
+    public static final String DB_NAME = "newsfeed.db";
+
+    // Database schemas are versioned.
+    public static final int DB_VERSION = 3;
+}

--- a/app/src/main/java/com/fknussel/news/DbHelper.java
+++ b/app/src/main/java/com/fknussel/news/DbHelper.java
@@ -1,0 +1,40 @@
+package com.fknussel.news;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+public class DbHelper extends SQLiteOpenHelper {
+
+    private static final String TAG = DbHelper.class.getSimpleName();
+
+    public DbHelper(Context context) {
+        super(context, PostContract.DB_NAME, null, PostContract.DB_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        // Called only once first time we create the database
+        String sql = String.format(
+                "create table %s (%s int primary key, %s text, %s text, %s text, %s text, %s text)",
+                PostContract.TABLE,
+                PostContract.Column.ID,
+                PostContract.Column.TITLE,
+                PostContract.Column.EXCERPT,
+                PostContract.Column.BODY,
+                PostContract.Column.CATEGORY,
+                PostContract.Column.DATE
+        );
+        db.execSQL(sql);
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // Gets called whenever existing version != new version, i.e. schema changed.
+        // This typically happens when you change the schema and release the application
+        // update to users who already have older version of your app.
+        // Typically you do ALTER TABLE ... but we wanna keep it simple here.
+        db.execSQL("drop table if exists " + PostContract.TABLE);
+        onCreate(db);
+    }
+}

--- a/app/src/main/java/com/fknussel/news/DbHelper.java
+++ b/app/src/main/java/com/fknussel/news/DbHelper.java
@@ -9,14 +9,15 @@ public class DbHelper extends SQLiteOpenHelper {
     private static final String TAG = DbHelper.class.getSimpleName();
 
     public DbHelper(Context context) {
-        super(context, PostContract.DB_NAME, null, PostContract.DB_VERSION);
+        super(context, DbContract.DB_NAME, null, DbContract.DB_VERSION);
     }
 
     @Override
     public void onCreate(SQLiteDatabase db) {
         // Called only once first time we create the database
-        String sql = String.format(
-                "create table %s (%s int primary key, %s text, %s text, %s text, %s text, %s text)",
+        // First create the posts table
+        String sqlCreatePosts = String.format(
+                "CREATE TABLE %s (%s int primary key, %s text, %s text, %s text, %s text, %s text)",
                 PostContract.TABLE,
                 PostContract.Column.ID,
                 PostContract.Column.TITLE,
@@ -25,7 +26,19 @@ public class DbHelper extends SQLiteOpenHelper {
                 PostContract.Column.CATEGORY,
                 PostContract.Column.DATE
         );
-        db.execSQL(sql);
+        db.execSQL(sqlCreatePosts);
+        
+        // Then create the media table (one to many relationship
+        // Each post may have zero, one or multiple media items attached
+        String sqlCreateMedia = String.format(
+                "CREATE TABLE %s (%s int primary key, %s int, %s text, %s text)",
+                MediaContract.TABLE,
+                MediaContract.Column.ID,
+                MediaContract.Column.POST_ID,
+                MediaContract.Column.URL,
+                MediaContract.Column.TYPE
+        );
+        db.execSQL(sqlCreateMedia);
     }
 
     @Override
@@ -35,6 +48,7 @@ public class DbHelper extends SQLiteOpenHelper {
         // update to users who already have older version of your app.
         // Typically you do ALTER TABLE ... but we wanna keep it simple here.
         db.execSQL("drop table if exists " + PostContract.TABLE);
+        db.execSQL("drop table if exists " + MediaContract.TABLE);
         onCreate(db);
     }
 }

--- a/app/src/main/java/com/fknussel/news/DetailActivity.java
+++ b/app/src/main/java/com/fknussel/news/DetailActivity.java
@@ -1,5 +1,8 @@
 package com.fknussel.news;
 
+import android.app.Activity;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
@@ -21,6 +24,7 @@ import com.squareup.picasso.Picasso;
 import com.squareup.picasso.Target;
 
 import java.io.File;
+import java.util.ArrayList;
 
 import retrofit.Callback;
 import retrofit.RetrofitError;
@@ -30,7 +34,7 @@ import retrofit.client.Response;
 public class DetailActivity extends ActionBarActivity {
 
     public final String TAG = DetailActivity.class.getSimpleName();
-    
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -47,39 +51,98 @@ public class DetailActivity extends ActionBarActivity {
             final TextView postDate = (TextView) findViewById(R.id.detail_post_date);
             final ImageView postImage = (ImageView) findViewById(R.id.detail_post_image);
 
-            ApiClient.getApiInterface().getPost(id, new Callback<Post>() {
-                @Override
-                public void success(Post post, Response response) {
-                    postTitle.setText(post.getTitle());
-                    
-                    if (!TextUtils.isEmpty(post.getExcerpt())) {
-                        postExcerpt.setText(TextHelper.processHtml(post.getExcerpt()));
-                    }
-                    
-                    if (!TextUtils.isEmpty(post.getBody())) {
-                        postBody.setText(TextHelper.processHtml(post.getBody()));
-                    } else {
-                        // if there's no body contributed, we don't want the excerpt to be bold
-                        postExcerpt.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
-                        // we should also enforce the body TextView not to take up any space in the layout
-                        postBody.setPadding(0, 0, 0, 0);
-                    }
-                    
-                    postCategory.setText(post.getCategory());
-                    postDate.setText(DateHelper.getHumanFriendlyDate(post.getDate()));
+            // query the API only if the post is not stored locally
+            DbHelper dbHelper = new DbHelper(this);
+            SQLiteDatabase db = dbHelper.getReadableDatabase();
 
-                    Log.d(TAG, post.getBody());
+            // Cursor to query the database
+            String postQuery = "SELECT * FROM " + PostContract.TABLE +
+                    " WHERE " + PostContract.Column.ID + " = " + id;
+            Cursor postCursor = db.rawQuery(postQuery, null);
+
+            if (postCursor != null && postCursor.getCount() > 0) {
+                while (postCursor.moveToNext()) {
+                    String title = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.TITLE));
+                    String excerpt = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.EXCERPT));
+                    String body = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.BODY));
+                    String category = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.CATEGORY));
+                    String date = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.DATE));
+
+                    // Fetch the media items associated to the current post (if any)
+                    ArrayList<Media> media = new ArrayList<>();
+
+                    String mediaQuery = "SELECT * FROM " + MediaContract.TABLE +
+                            " WHERE " + MediaContract.Column.POST_ID + " = " + id +
+                            " ORDER BY " + MediaContract.DEFAULT_SORT;
+
+                    Cursor mediaCursor = db.rawQuery(mediaQuery, null);
+
+                    while (mediaCursor.moveToNext()) {
+                        int mediaId = mediaCursor.getInt(mediaCursor.getColumnIndex(MediaContract.Column.ID));
+                        String url = mediaCursor.getString(mediaCursor.getColumnIndex(MediaContract.Column.URL));
+                        String type = mediaCursor.getString(mediaCursor.getColumnIndex(MediaContract.Column.TYPE));
+
+                        media.add(new Media(mediaId, id, type, url));
+                    }
+
+                    mediaCursor.close();
+
+                    Post post = new Post(id, title, excerpt, body, category, date, media);
                     
-                    Picasso.with(getApplicationContext())
-                            .load(post.getImage())
-                            .into(postImage);
+                    populatePost(post, postTitle, postExcerpt, postBody, postCategory, postDate, postImage);
+                    Toast.makeText(this, "data fetched from DB", Toast.LENGTH_SHORT).show();
+
                 }
 
-                @Override
-                public void failure(RetrofitError error) {
+                postCursor.close();
+            } else {
+                ApiClient.getApiInterface().getPost(id, new Callback<Post>() {
+                    @Override
+                    public void success(Post post, Response response) {
+                        populatePost(post, postTitle, postExcerpt, postBody, postCategory, postDate, postImage);
+                        Toast.makeText(getApplicationContext(), "data fetched from API", Toast.LENGTH_SHORT).show();
+                    }
 
-                }
-            });
+                    @Override
+                    public void failure(RetrofitError error) {
+
+                    }
+                });
+            }
+        }
+    }
+    
+    private void populatePost(Post post, TextView title, TextView excerpt, TextView body, 
+                              TextView category, TextView date, ImageView image) {
+        title.setText(post.getTitle());
+
+        if (!TextUtils.isEmpty(post.getExcerpt())) {
+            excerpt.setText(TextHelper.processHtml(post.getExcerpt()));
+        }
+
+        if (!TextUtils.isEmpty(post.getBody())) {
+            body.setText(TextHelper.processHtml(post.getBody()));
+        } else {
+            // if there's no body contributed, we don't want the excerpt to be bold
+            excerpt.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
+            // we should also enforce the body TextView not to take up any space in the layout
+            body.setPadding(0, 0, 0, 0);
+            // finally we add a bottom padding to the excerpt textview
+            // so as to have it separated from the browse image gallery button
+            //postExcerpt.setPadding(R.dimen.detail_text_padding, R.dimen.detail_text_padding, R.dimen.detail_text_padding, R.dimen.detail_text_padding);
+        }
+
+        category.setText(post.getCategory());
+        date.setText(DateHelper.getHumanFriendlyDate(post.getDate()));
+
+        if (post.hasImage()) {
+            Log.d(TAG, "--------------- IMAGE: " + post.getImage());
+        }
+        
+        if (post.hasImage()) {
+            Picasso.with(getApplicationContext())
+                    .load(post.getImage())
+                    .into(image);
         }
     }
 

--- a/app/src/main/java/com/fknussel/news/DetailActivity.java
+++ b/app/src/main/java/com/fknussel/news/DetailActivity.java
@@ -2,11 +2,13 @@ package com.fknussel.news;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.text.Html;
+import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Menu;
@@ -39,15 +41,35 @@ public class DetailActivity extends ActionBarActivity {
 
             // final since they need to be accessed from within an inner class
             final TextView postTitle = (TextView) findViewById(R.id.detail_post_title);
+            final TextView postExcerpt = (TextView) findViewById(R.id.detail_post_excerpt);
             final TextView postBody = (TextView) findViewById(R.id.detail_post_body);
+            final TextView postCategory = (TextView) findViewById(R.id.detail_post_category);
+            final TextView postDate = (TextView) findViewById(R.id.detail_post_date);
             final ImageView postImage = (ImageView) findViewById(R.id.detail_post_image);
 
             ApiClient.getApiInterface().getPost(id, new Callback<Post>() {
                 @Override
                 public void success(Post post, Response response) {
                     postTitle.setText(post.getTitle());
-                    postBody.setText(Html.fromHtml(post.getBody()));
+                    
+                    if (!TextUtils.isEmpty(post.getExcerpt())) {
+                        postExcerpt.setText(TextHelper.processHtml(post.getExcerpt()));
+                    }
+                    
+                    if (!TextUtils.isEmpty(post.getBody())) {
+                        postBody.setText(TextHelper.processHtml(post.getBody()));
+                    } else {
+                        // if there's no body contributed, we don't want the excerpt to be bold
+                        postExcerpt.setTypeface(Typeface.create("sans-serif-light", Typeface.NORMAL));
+                        // we should also enforce the body TextView not to take up any space in the layout
+                        postBody.setPadding(0, 0, 0, 0);
+                    }
+                    
+                    postCategory.setText(post.getCategory());
+                    postDate.setText(DateHelper.getHumanFriendlyDate(post.getDate()));
 
+                    Log.d(TAG, post.getBody());
+                    
                     Picasso.with(getApplicationContext())
                             .load(post.getImage())
                             .into(postImage);

--- a/app/src/main/java/com/fknussel/news/LocalNewsFragment.java
+++ b/app/src/main/java/com/fknussel/news/LocalNewsFragment.java
@@ -1,7 +1,10 @@
 package com.fknussel.news;
 
 import android.app.Activity;
+import android.content.ContentValues;
 import android.content.Intent;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -9,10 +12,14 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Adapter;
 import android.widget.AdapterView;
 import android.widget.ListView;
+import android.widget.Toast;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import retrofit.Callback;
 import retrofit.RetrofitError;
@@ -36,20 +43,75 @@ public class LocalNewsFragment extends Fragment {
 
         // Needs to be final so that it can be accessed from the onItemClickListener
         final NewsAdapter newsAdapter = new NewsAdapter(getActivity());
-
-        ApiClient.getApiInterface().getPosts(1, new Callback<List<Post>>() {
-            @Override
-            public void success(List<Post> posts, Response response) {
-                newsAdapter.addAll(posts);
-                newsAdapter.notifyDataSetChanged();
-            }
-
-            @Override
-            public void failure(RetrofitError error) {
-                Log.d(TAG, error.getMessage());
-            }
-        });
         
+        ArrayList<Post> posts = new ArrayList<>();
+
+        // if we have cached data, do not query the API
+        DbHelper dbHelper = new DbHelper(getActivity());
+        SQLiteDatabase db = dbHelper.getReadableDatabase();
+
+        // Cursor to query the database
+        String postQuery = "SELECT * FROM " + PostContract.TABLE +
+                " ORDER BY " + PostContract.DEFAULT_SORT; 
+        Cursor postCursor = db.rawQuery(postQuery, null);
+
+        if (postCursor != null && postCursor.getCount() > 0) {
+            if (postCursor.moveToFirst()) {
+                do {
+                    int id = postCursor.getInt(postCursor.getColumnIndex(PostContract.Column.ID));
+                    String title = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.TITLE));
+                    String excerpt = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.EXCERPT));
+                    String body = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.BODY));
+                    String category = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.CATEGORY));
+                    String date = postCursor.getString(postCursor.getColumnIndex(PostContract.Column.DATE));
+
+                    // Fetch the media items associated to the current post (if any)
+                    ArrayList<Media> media = new ArrayList<>();
+
+                    String mediaQuery = "SELECT * FROM " + MediaContract.TABLE +
+                            " WHERE " + MediaContract.Column.POST_ID + " = " + id +
+                            " ORDER BY " + MediaContract.DEFAULT_SORT;
+
+                    Cursor mediaCursor = db.rawQuery(mediaQuery, null);
+
+                    if (mediaCursor.moveToFirst()) {
+                        do {
+                            int mediaId = mediaCursor.getInt(mediaCursor.getColumnIndex(MediaContract.Column.ID));
+                            String url = mediaCursor.getString(mediaCursor.getColumnIndex(MediaContract.Column.URL));
+                            String type = mediaCursor.getString(mediaCursor.getColumnIndex(MediaContract.Column.TYPE));
+
+                            media.add(new Media(mediaId, id, type, url));
+                        } while (mediaCursor.moveToNext());
+
+                        mediaCursor.close();
+                    }
+
+                    // Add the post to the adapter
+                    Post post = new Post(id, title, excerpt, body, category, date, media);
+                    posts.add(post);
+
+                } while (postCursor.moveToNext());
+
+                postCursor.close();
+                
+                newsAdapter.addAll(posts);
+
+                Toast.makeText(getActivity(), "timeline data fetched from DB", Toast.LENGTH_SHORT).show();
+                
+                // here we should query the API again to fetch just
+                // the latest posts and somehow merge them into
+                // our adapter existing data
+                // fetchPostsFromApi(newsAdapter, 1);
+
+            }
+        } else {
+            // query the API
+            fetchPostsFromApi(newsAdapter, 1);
+        }
+
+        // DB connection clean up
+        dbHelper.close();
+
         ListView listview = (ListView) rootView.findViewById(R.id.listview_news);
 
         listview.setAdapter(newsAdapter);
@@ -67,14 +129,67 @@ public class LocalNewsFragment extends Fragment {
         return rootView;
     }
 
-    // onAttach() gets called when the fragment gets associated to main activity
-
     @Override
     public void onAttach(Activity activity) {
+        // onAttach() gets called when the fragment gets associated to main activity
         super.onAttach(activity);
 
         // this is gonna allow us to call over into main activity
         // and make sure the action bar title matches our fragment title
         ((MainActivity) activity).onSectionAttached(1);
+    }
+    
+    private void fetchPostsFromApi(final NewsAdapter newsAdapter, int paginationIndex) {
+        ApiClient.getApiInterface().getPosts(1, new Callback<List<Post>>() {
+            @Override
+            public void success(List<Post> posts, Response response) {
+                newsAdapter.addAll(posts);
+                newsAdapter.notifyDataSetChanged();
+
+                // Cache the data
+                DbHelper dbHelper = new DbHelper(getActivity());
+                SQLiteDatabase db = dbHelper.getWritableDatabase();
+
+                ContentValues values = new ContentValues();
+
+                try {
+                    for (Post post : posts) {
+                        // save the current post to the database
+                        values.clear();
+
+                        values.put(PostContract.Column.ID, post.getId());
+                        values.put(PostContract.Column.TITLE, post.getTitle());
+                        values.put(PostContract.Column.EXCERPT, post.getExcerpt());
+                        values.put(PostContract.Column.BODY, post.getBody());
+                        values.put(PostContract.Column.CATEGORY, post.getCategory());
+                        values.put(PostContract.Column.DATE, post.getDate());
+
+                        db.insertWithOnConflict(PostContract.TABLE, null, values, SQLiteDatabase.CONFLICT_IGNORE);
+
+                        // save the associated media items
+                        if (post.hasMedia()) {
+                            for (Media media : post.getMedia()) {
+                                values.clear();
+
+                                values.put(MediaContract.Column.ID, new Random().nextInt((99999 - 1) + 1) + 1);
+                                values.put(MediaContract.Column.POST_ID, post.getId());
+                                values.put(MediaContract.Column.URL, media.getUrl());
+                                values.put(MediaContract.Column.TYPE, media.getType());
+
+                                db.insertWithOnConflict(MediaContract.TABLE, null, values, SQLiteDatabase.CONFLICT_IGNORE);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    Log.d(TAG, "Failed to fetch news feed");
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public void failure(RetrofitError error) {
+                Log.d(TAG, error.getMessage());
+            }
+        });
     }
 }

--- a/app/src/main/java/com/fknussel/news/MainActivity.java
+++ b/app/src/main/java/com/fknussel/news/MainActivity.java
@@ -1,6 +1,7 @@
 package com.fknussel.news;
 
 import android.app.Activity;
+import android.database.sqlite.SQLiteDatabase;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.ActionBar;
 import android.support.v4.app.Fragment;
@@ -120,6 +121,13 @@ public class MainActivity extends ActionBarActivity
             case R.id.action_search:
                 //startService(new Intent(this, RefreshService.class));
                 Toast.makeText(this, "search", Toast.LENGTH_SHORT).show();
+                break;
+            case R.id.action_purge:
+                DbHelper helper = new DbHelper(this);
+                SQLiteDatabase db = helper.getWritableDatabase();
+                db.delete(PostContract.TABLE, null, null);
+                db.delete(MediaContract.TABLE, null, null);
+                Toast.makeText(this, "data purged successfully :)", Toast.LENGTH_SHORT).show();
                 break;
         }
 

--- a/app/src/main/java/com/fknussel/news/Media.java
+++ b/app/src/main/java/com/fknussel/news/Media.java
@@ -11,7 +11,6 @@ public class Media {
     private String url;
     
     private static final String IMAGE_BASE_URL = "http://www.freyre.com.ar/files/";
-    private static final String VIDEO_BASE_URL = "";
 
     public Media(int id, int postId, String type, String url) {
         this.id = id;
@@ -29,10 +28,15 @@ public class Media {
     }
 
     public String getUrl() {
+
         if (type.equals("imagen")) {
-            return IMAGE_BASE_URL + url;
+            if (url.startsWith(IMAGE_BASE_URL)) {
+                return url;
+            } else {
+                return IMAGE_BASE_URL + url;
+            }
         } else {
-            return VIDEO_BASE_URL + url;
+            return url;
         }
     }
 

--- a/app/src/main/java/com/fknussel/news/Media.java
+++ b/app/src/main/java/com/fknussel/news/Media.java
@@ -5,15 +5,27 @@ package com.fknussel.news;
  */
 public class Media {
     
+    private int id;
+    private int postId;
     private String type;
     private String url;
     
     private static final String IMAGE_BASE_URL = "http://www.freyre.com.ar/files/";
     private static final String VIDEO_BASE_URL = "";
 
-    public Media(String type, String url) {
+    public Media(int id, int postId, String type, String url) {
+        this.id = id;
+        this.postId = postId;
         this.type = type;
         this.url = url;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getPostId() {
+        return postId;
     }
 
     public String getUrl() {

--- a/app/src/main/java/com/fknussel/news/MediaContract.java
+++ b/app/src/main/java/com/fknussel/news/MediaContract.java
@@ -1,0 +1,22 @@
+package com.fknussel.news;
+
+import android.provider.BaseColumns;
+
+public class MediaContract {
+
+    // Table name
+    public static final String TABLE = "media";
+
+    // Sort order
+    public static final String DEFAULT_SORT = Column.ID + " ASC";
+
+    // Table definition
+    public class Column {
+        // Although the ID could be any name, there’s a convention in Android
+        // to name it _id, for which it provides an API-level contract as well.
+        public static final String ID = BaseColumns._ID;
+        public static final String POST_ID = "post_id";
+        public static final String URL = "url";
+        public static final String TYPE = "type";
+    }
+}

--- a/app/src/main/java/com/fknussel/news/NewsAdapter.java
+++ b/app/src/main/java/com/fknussel/news/NewsAdapter.java
@@ -51,7 +51,7 @@ public class NewsAdapter extends ArrayAdapter<Post> {
         // Populate the data into the template view using the data object
         postTitle.setText(post.getTitle());
         postCategory.setText(post.getCategory());
-        postDate.setText(post.getDate());
+        postDate.setText(DateHelper.getHumanFriendlyDate(post.getDate()));
         
         if (post.hasImage()) {
             Picasso.with(getContext())

--- a/app/src/main/java/com/fknussel/news/Post.java
+++ b/app/src/main/java/com/fknussel/news/Post.java
@@ -47,36 +47,7 @@ public class Post {
     }
 
     public String getDate() {
-        ArrayList<String> months = new ArrayList<>();
-        months.add("Enero");
-        months.add("Febrero");
-        months.add("Marzo");
-        months.add("Abril");
-        months.add("Mayo");
-        months.add("Junio");
-        months.add("Julio");
-        months.add("Agosto");
-        months.add("Septiembre");
-        months.add("Octubre");
-        months.add("Noviembre");
-        months.add("Diciembre");
-
-        ArrayList<String> days = new ArrayList<>();
-        days.add("Domingo");
-        days.add("Lunes");
-        days.add("Martes");
-        days.add("Miercoles");
-        days.add("Jueves");
-        days.add("Viernes");
-        days.add("Sábado");
-        
-        DateTime dt = new DateTime(date);
-        
-        String weekDay = days.get(dt.getWeekDay() - 1);
-        String day = dt.getDay().toString();
-        String month = months.get(dt.getMonth() - 1);
-        
-        return weekDay + " " + day + " de " + month;
+        return date;
     }
     
     public ArrayList<Media> getMedia() {

--- a/app/src/main/java/com/fknussel/news/PostContract.java
+++ b/app/src/main/java/com/fknussel/news/PostContract.java
@@ -4,19 +4,11 @@ import android.provider.BaseColumns;
 
 public class PostContract {
 
-    // DB specific constants
-    // ---------------------------
-    // This is the actual SQLite file that will contain the database
-    public static final String DB_NAME = "newsfeed.db";
-
-    // Database schemas are versioned.
-    public static final int DB_VERSION = 1;
-
-    // Sort order
-    public static final String DEFAULT_SORT = Column.DATE + " DESC";
-
     // Table name
     public static final String TABLE = "posts";
+
+    // Sort order
+    public static final String DEFAULT_SORT = Column.ID + " DESC";
 
     // Table definition
     public class Column {

--- a/app/src/main/java/com/fknussel/news/PostContract.java
+++ b/app/src/main/java/com/fknussel/news/PostContract.java
@@ -1,0 +1,32 @@
+package com.fknussel.news;
+
+import android.provider.BaseColumns;
+
+public class PostContract {
+
+    // DB specific constants
+    // ---------------------------
+    // This is the actual SQLite file that will contain the database
+    public static final String DB_NAME = "newsfeed.db";
+
+    // Database schemas are versioned.
+    public static final int DB_VERSION = 1;
+
+    // Sort order
+    public static final String DEFAULT_SORT = Column.DATE + " DESC";
+
+    // Table name
+    public static final String TABLE = "posts";
+
+    // Table definition
+    public class Column {
+        // Although the ID could be any name, there’s a convention in Android
+        // to name it _id, for which it provides an API-level contract as well.
+        public static final String ID = BaseColumns._ID;
+        public static final String TITLE = "title";
+        public static final String EXCERPT = "excerpt";
+        public static final String BODY = "body";
+        public static final String CATEGORY = "category";
+        public static final String DATE = "date";
+    }
+}

--- a/app/src/main/java/com/fknussel/news/TextHelper.java
+++ b/app/src/main/java/com/fknussel/news/TextHelper.java
@@ -1,0 +1,21 @@
+package com.fknussel.news;
+
+import android.text.Html;
+
+public class TextHelper {
+
+    public static CharSequence trim(CharSequence text) {
+        while (text.charAt(text.length() - 1) == '\n') {
+            text = text.subSequence(0, text.length() - 1);
+        }
+        return text;
+    }
+    
+    public static String removeEmptyParagraphs(String text) {
+        return text.replaceAll("<p> </p>", " ");
+    }
+    
+    public static CharSequence processHtml(String text) {
+        return trim(Html.fromHtml(removeEmptyParagraphs(text)));
+    }
+}

--- a/app/src/main/res/drawable/gradient_shape.xml
+++ b/app/src/main/res/drawable/gradient_shape.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" 
+    android:shape="rectangle" >
+    <gradient
+        android:angle="90"
+        android:endColor="#d000"
+        android:centerColor="#0000"
+        android:startColor="#d000"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -32,16 +32,79 @@
             android:textSize="22dp"
             android:fontFamily="sans-serif-light" />
 
+        <LinearLayout
+            android:id="@+id/detail_post_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/detail_post_image"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/detail_post_category"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="8dp"
+                android:fontFamily="sans-serif-light"
+                android:textSize="14sp"
+                android:background="@color/primary_dark"
+                android:textColor="@android:color/white"
+                android:gravity="center" />
+
+            <TextView
+                android:id="@+id/detail_post_date"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:padding="8dp"
+                android:fontFamily="sans-serif-light"
+                android:textSize="14sp"
+                android:background="@color/primary"
+                android:textColor="@android:color/white"
+                android:gravity="center" />
+            
+            </LinearLayout>
+
+        <TextView
+            android:id="@+id/detail_post_excerpt"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/detail_post_details"
+            android:lineSpacingMultiplier="1.3"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="6dp"
+            android:fontFamily="sans-serif-bold"
+            android:textSize="17sp"
+            android:textStyle="bold"
+            android:textIsSelectable="true" />
+        
         <TextView
             android:id="@+id/detail_post_body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/detail_post_image"
+            android:layout_below="@id/detail_post_excerpt"
             android:lineSpacingMultiplier="1.3"
-            android:padding="25dp"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
+            android:paddingBottom="20dp"
+            android:fontFamily="sans-serif-light"
+            android:textSize="17sp"
+            android:textIsSelectable="true" />
+
+        <TextView
+            android:id="@+id/detail_post_gallery"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/detail_post_body"
+            android:padding="20dp"
             android:fontFamily="sans-serif-light"
             android:textSize="17dp"
-            android:textIsSelectable="true" />
+            android:text="Browse Image Gallery"
+            android:background="@color/primary_dark"
+            android:textColor="@android:color/white"
+            android:gravity="center" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -7,14 +7,29 @@
     
     <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
+        android:layout_height="wrap_content"
+         >
+        
         <ImageView
             android:id="@+id/detail_post_image"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:scaleType="fitStart"
-            android:adjustViewBounds="true" />
+            android:adjustViewBounds="true"
+            android:src="@drawable/ic_placeholder" />
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scaleType="fitStart"
+            android:adjustViewBounds="true"
+            android:src="@drawable/gradient_shape"
+            android:layout_alignLeft="@id/detail_post_image"
+            android:layout_alignRight="@id/detail_post_image"
+            android:layout_alignStart="@id/detail_post_image"
+            android:layout_alignEnd="@id/detail_post_image"
+            android:layout_alignTop="@id/detail_post_image"
+            android:layout_alignBottom="@id/detail_post_image" />
 
         <TextView
             android:id="@+id/detail_post_title"
@@ -24,11 +39,8 @@
             android:layout_alignStart="@id/detail_post_image"
             android:layout_alignBottom="@id/detail_post_image"
             android:padding="10dp"
-            android:layout_marginLeft="0dp"
-            android:layout_marginBottom="15dp"
-            android:layout_marginRight="20dp"
+
             android:gravity="left"
-            android:background="#A6000000"
             android:textColor="#FFFFFF"
             android:textSize="22dp"
             android:fontFamily="sans-serif-light" />

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -2,7 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".DetailActivity">
+    tools:context=".DetailActivity"
+    android:fillViewport="true">
     
     <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
@@ -93,10 +94,11 @@
             android:textSize="17sp"
             android:textIsSelectable="true" />
 
-        <TextView
+        <Button
             android:id="@+id/detail_post_gallery"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
             android:layout_below="@id/detail_post_body"
             android:padding="20dp"
             android:fontFamily="sans-serif-light"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -21,5 +21,10 @@
         android:orderInCategory="100"
         android:icon="@android:drawable/ic_menu_rotate"
         app:showAsAction="never" />
+
+    <item android:id="@+id/action_purge"
+        android:title="@string/action_purge"
+        android:orderInCategory="400"
+        app:showAsAction="never" />
     
 </menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="secondary_text">#727272</color>
     <color name="icons">#FFFFFF</color>
     <color name="divider">#B6B6B6</color>
+    <color name="transparent">#0000</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,5 +6,6 @@
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="listview_padding">10dp</dimen>
     <dimen name="navigation_drawer_width">240dp</dimen>
+    <dimen name="detail_text_padding">20dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="action_refresh">Refresh</string>
     <string name="action_search">Search</string>
     <string name="action_share">Share</string>
+    <string name="action_purge">Purge</string>
 
     <!-- Brand -->
     <string name="company_name">Company Name</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- the theme applied to the application or activity -->
+    <style name="CustomActionBarTheme"
+        parent="@style/Theme.AppCompat.Light.DarkActionBar">
+        <item name="android:actionBarStyle">@style/MyActionBar</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowActionBarOverlay">true</item>
+        <item name="windowActionBarOverlay">true</item> <!-- for ActionBarSherlock -->
+        <!-- Support library compatibility -->
+        <item name="actionBarStyle">@style/MyActionBar</item>
+    </style>
+
+    <!-- ActionBar styles -->
+    <style name="MyActionBar"
+        parent="@style/Widget.AppCompat.Light.ActionBar.Solid.Inverse">
+        <item name="android:background">@color/transparent</item>
+        <!-- Support library compatibility -->
+        <item name="background">@color/transparent</item>
+    </style>
+</resources>


### PR DESCRIPTION
So far, whenever we want to display a particular post or list the latest articles, we needed to query the API. This is not cool whatsoever, unnecessary network calls should be avoided whenever possible. Instead we should cache the data into our local database immediately after we query the web service for the first time. This is what this branch focuses on, making the app more efficient in terms of network calls.

We also went ahead and made some UI tweaks to `DetailActivity`: the action bar is now transparent, the pictures kinda overlay the action bar but are still fully visible since it's transparent now, also posts' titles get displayed on top of a black-to-transparent gradient applied to the image (we are no longer using the semi-opaque black box underneath the title).